### PR TITLE
File chooser nativo

### DIFF
--- a/mars/tools/AbstractMarsToolAndApplication.java
+++ b/mars/tools/AbstractMarsToolAndApplication.java
@@ -331,6 +331,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
          openFileButton.addActionListener(
                 new ActionListener() {
                    public void actionPerformed(ActionEvent e) {
+                     // Use the swing implementation here instead of the FileChooser interface
+                     // because this code adds checkboxes and such
                      JFileChooser fileChooser = new JFileChooser();
                      JCheckBox multiFileAssembleChoose = new JCheckBox("Assemble all in selected file's directory",multiFileAssemble);
                      multiFileAssembleChoose.setToolTipText("If checked, selected file will be assembled first and all other assembly files in directory will be assembled also.");

--- a/mars/tools/FileChooserDefaultExtensionDecorator.java
+++ b/mars/tools/FileChooserDefaultExtensionDecorator.java
@@ -1,0 +1,52 @@
+package mars.tools;
+
+import java.awt.Component;
+import java.io.File;
+
+import mars.venus.FileChooser;
+
+public class FileChooserDefaultExtensionDecorator implements FileChooser {
+
+    private FileChooser underlying;
+    private String extension;
+
+    public FileChooserDefaultExtensionDecorator(FileChooser underlying, String extension) {
+        this.underlying = underlying;
+        this.extension = extension;
+    }
+
+    @Override
+    public void setSelectedFile(File file) {
+        underlying.setSelectedFile(file);
+    }
+
+    @Override
+    public File getSelectedFile() {
+        File f = underlying.getSelectedFile();
+        if (!f.exists() && !f.getName().contains(".")) {
+            f = new File(f.getAbsolutePath() + "." + extension);
+        }
+        return f;
+    }
+
+    @Override
+    public void setDialogTitle(String title) {
+        underlying.setDialogTitle(title);
+    }
+
+    @Override
+    public int showSaveDialog(Component parent) {
+        return underlying.showSaveDialog(parent);
+    }
+
+    @Override
+    public int showOpenDialog(Component parent) {
+        return underlying.showOpenDialog(parent);
+    }
+
+    @Override
+    public boolean automaticallyAsksOverwrite() {
+        return underlying.automaticallyAsksOverwrite();
+    }
+
+}

--- a/mars/venus/AWTFileChooser.java
+++ b/mars/venus/AWTFileChooser.java
@@ -1,0 +1,60 @@
+package mars.venus;
+
+import java.awt.Component;
+import java.awt.FileDialog;
+import java.io.File;
+
+import javax.swing.JFileChooser;
+
+public class AWTFileChooser extends FileDialog implements FileChooser {
+    public AWTFileChooser(String dirPath) {
+        super((java.awt.Frame) null);
+        setDirectory(dirPath);
+    }
+
+    public AWTFileChooser() {
+        super((java.awt.Frame) null);
+    }
+
+    @Override
+    public File getSelectedFile() {
+        return new File(getFile()).getAbsoluteFile();
+    }
+
+    @Override
+    public void setSelectedFile(File file) {
+        setFile(file.getAbsolutePath());
+    }
+
+    @Override
+    public void setDialogTitle(String title) {
+        setTitle(title);
+    }
+
+    @Override
+    public int showSaveDialog(Component unused) {
+        return showDialogWithMode(FileDialog.SAVE);
+    }
+
+    @Override
+    public int showOpenDialog(Component unused) {
+        return showDialogWithMode(FileDialog.LOAD);
+    }
+
+    private int showDialogWithMode(int mode) {
+        setMode(mode);
+        setMultipleMode(false);
+        setVisible(true);
+        String choice = getFile();
+        if (choice != null) {
+            return JFileChooser.APPROVE_OPTION;
+        }
+
+        return JFileChooser.CANCEL_OPTION;
+    }
+
+    @Override
+    public boolean automaticallyAsksOverwrite() {
+        return true;
+    }
+}

--- a/mars/venus/EditTabbedPane.java
+++ b/mars/venus/EditTabbedPane.java
@@ -354,12 +354,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                } 
                else {
                   File f = new File(editPane.getPathname());
-                  if (f != null) {
-                     saveDialog = new JFileChooser(f.getParent());
-                  } 
-                  else {
-                     saveDialog = new JFileChooser(editor.getCurrentSaveDirectory());
-                  }
+                  saveDialog = new JFileChooser(f.getParent());
                }
                String paneFile = editPane.getFilename();
                if (paneFile != null) saveDialog.setSelectedFile(new File(paneFile));

--- a/mars/venus/FileChooser.java
+++ b/mars/venus/FileChooser.java
@@ -1,0 +1,29 @@
+package mars.venus;
+
+import java.awt.Component;
+import java.io.File;
+
+import mars.tools.FileChooserDefaultExtensionDecorator;
+
+public interface FileChooser {
+    public void setSelectedFile(File file);
+    public File getSelectedFile();
+    public void setDialogTitle(String title);
+    public int showSaveDialog(Component parent);
+    public int showOpenDialog(Component parent);
+    public boolean automaticallyAsksOverwrite();
+
+    public static FileChooser createForCurrentPlatform(String dirPath) {
+        FileChooser fc;
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            fc = new AWTFileChooser(dirPath);
+        } else {
+            fc = new SwingFileChooser(dirPath);
+        }
+        return new FileChooserDefaultExtensionDecorator(fc, "mar");
+    }
+
+    public static FileChooser createForCurrentPlatform() {
+        return createForCurrentPlatform(null);
+    }
+}

--- a/mars/venus/FileDumpMemoryAction.java
+++ b/mars/venus/FileDumpMemoryAction.java
@@ -215,10 +215,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
    	// segment (memory range) and format selections and save to the file.
        private boolean performDump(int firstAddress, int lastAddress, DumpFormat format) {	
          File theFile = null;
-         JFileChooser saveDialog = null;
+         FileChooser saveDialog = null;
          boolean operationOK = false;
       
-         saveDialog = new JFileChooser(mainUI.getEditor().getCurrentSaveDirectory());
+         saveDialog = FileChooser.createForCurrentPlatform(mainUI.getEditor().getCurrentSaveDirectory());
          saveDialog.setDialogTitle(title);
          while (!operationOK) {
             int decision = saveDialog.showSaveDialog(mainUI);

--- a/mars/venus/FileOpenAction.java
+++ b/mars/venus/FileOpenAction.java
@@ -43,7 +43,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     public class FileOpenAction extends GuiAction {
     
       private File mostRecentlyOpenedFile;
-      private JFileChooser fileChooser;
+      private FileChooser fileChooser;
       private int fileFilterCount;
       private ArrayList fileFilterList;
       private PropertyChangeListener listenForUserAddedFileFilter;

--- a/mars/venus/SettingsExceptionHandlerAction.java
+++ b/mars/venus/SettingsExceptionHandlerAction.java
@@ -158,7 +158,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
    	// Associated action class: selecting exception handler file.  Attached to handler selector.
        private class ExceptionHandlerSelectionAction implements ActionListener {
           public void actionPerformed(ActionEvent e) {
-            JFileChooser chooser = new JFileChooser();
+            FileChooser chooser = FileChooser.createForCurrentPlatform();
             String pathname = Globals.getSettings().getExceptionHandler();
             if (pathname != null) {
                File file = new File(pathname);

--- a/mars/venus/SwingFileChooser.java
+++ b/mars/venus/SwingFileChooser.java
@@ -1,0 +1,18 @@
+package mars.venus;
+
+import javax.swing.JFileChooser;
+
+public class SwingFileChooser extends JFileChooser implements FileChooser {
+    public SwingFileChooser(String dirPath) {
+        super(dirPath);
+    }
+
+    public SwingFileChooser() {
+        super();
+    }
+
+    @Override
+    public boolean automaticallyAsksOverwrite() {
+        return false;
+    }
+}


### PR DESCRIPTION
Devido a reclamações sobre o mecanismo de abrir/salvar arquivos ser contraintuitivo, utilizar o file chooser nativo quando executando na plataforma Windows.